### PR TITLE
dropped keep alive

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: gautamkrishnar/keepalive-workflow@v1
     - name: Setup Julia
       uses: julia-actions/setup-julia@v1
       with:


### PR DESCRIPTION
Dropping keep alive workflow as its been banned by github

#100 